### PR TITLE
Adding gzip compression detection for reading and bgzip compression for write. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ memmap2 = "0.7.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 serde = { version = "1.0.183", features = ["derive"] }
+niffler = {version = "2.5.0", default-features = false, features = ["gz"]}
+gzp = "0.11.3"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/src/io/general.rs
+++ b/src/io/general.rs
@@ -1,15 +1,27 @@
 use anyhow::Result;
+use gzp::deflate::Bgzf;
+use gzp::{Compression, ZBuilder};
+use niffler::get_reader;
+use std::ffi::OsStr;
+use std::path::Path;
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter, Write},
 };
+const COMPRESSION_THREADS: usize = 4;
+const COMPRESSION_LEVEL: u32 = 6;
+
+fn compression_aware_read_buffer(file: File) -> Result<Box<dyn BufRead>> {
+    let buffer = BufReader::new(file);
+    let (reader, _compression) = get_reader(Box::new(buffer))?;
+    Ok(Box::new(BufReader::new(reader)))
+}
 
 pub fn match_input(input: Option<String>) -> Result<Box<dyn BufRead>> {
     match input {
         Some(filename) => {
             let file = File::open(filename)?;
-            let buffer = BufReader::new(file);
-            Ok(Box::new(buffer))
+            compression_aware_read_buffer(file)
         }
         None => {
             let stdin = std::io::stdin();
@@ -20,13 +32,24 @@ pub fn match_input(input: Option<String>) -> Result<Box<dyn BufRead>> {
     }
 }
 
-pub fn match_output(output: Option<String>) -> Result<Box<dyn Write + Send>> {
+fn compression_aware_write_buffer(filename: String) -> Result<Box<dyn Write>> {
+    let file = File::create(filename.clone())?;
+    let buffer = BufWriter::new(file);
+    let ext = Path::new(&filename).extension();
+    if ext == Some(OsStr::new("gz")) || ext == Some(OsStr::new("bgz")) {
+        let writer = ZBuilder::<Bgzf, _>::new()
+            .num_threads(COMPRESSION_THREADS)
+            .compression_level(Compression::new(COMPRESSION_LEVEL))
+            .from_writer(buffer);
+        Ok(Box::new(writer))
+    } else {
+        Ok(Box::new(buffer))
+    }
+}
+
+pub fn match_output(output: Option<String>) -> Result<Box<dyn Write>> {
     match output {
-        Some(filename) => {
-            let file = File::create(filename)?;
-            let buffer = BufWriter::new(file);
-            Ok(Box::new(buffer))
-        }
+        Some(filename) => compression_aware_write_buffer(filename),
         None => {
             let stdout = std::io::stdout();
             let buffer = BufWriter::new(stdout);


### PR DESCRIPTION
Hi @noamteyssier,

Here is my first pass at modifying these functions. I dropped the `Send` trait from `match_output`, which I think is okay because it appears to be unused, but let me know if that is wrong. 

I should also do more testing as I have only tried a few files. 

(this PR starts work on #56)